### PR TITLE
Add fraud proof trigger logic

### DIFF
--- a/mocks/Application.go
+++ b/mocks/Application.go
@@ -68,6 +68,49 @@ func (_m *Application) Commit() types.ResponseCommit {
 	return r0
 }
 
+// Commit provides a mock function with given fields:
+func (_m *Application) GenerateFraudProof(_a0 types.RequestGenerateFraudProof) types.ResponseGenerateFraudProof {
+	ret := _m.Called(_a0)
+
+	var r0 types.ResponseGenerateFraudProof
+	if rf, ok := ret.Get(0).(func(types.RequestGenerateFraudProof) types.ResponseGenerateFraudProof); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(types.ResponseGenerateFraudProof)
+	}
+
+	return r0
+}
+
+// Commit provides a mock function with given fields:
+func (_m *Application) GetAppHash(_a0 types.RequestGetAppHash) types.ResponseGetAppHash {
+	ret := _m.Called(_a0)
+
+	var r0 types.ResponseGetAppHash
+	if rf, ok := ret.Get(0).(func(types.RequestGetAppHash) types.ResponseGetAppHash); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(types.ResponseGetAppHash)
+	}
+
+	return r0
+}
+
+// Commit provides a mock function with given fields:
+func (_m *Application) TriggerFraudProofGenerationMode(_a0 types.RequestTriggerFraudProofGenerationMode) types.ResponseTriggerFraudProofGenerationMode {
+	ret := _m.Called(_a0)
+
+	var r0 types.ResponseTriggerFraudProofGenerationMode
+	if rf, ok := ret.Get(0).(func(types.RequestTriggerFraudProofGenerationMode) types.ResponseTriggerFraudProofGenerationMode); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(types.ResponseTriggerFraudProofGenerationMode)
+	}
+
+	return r0
+}
+
+
 // DeliverTx provides a mock function with given fields: _a0
 func (_m *Application) DeliverTx(_a0 types.RequestDeliverTx) types.ResponseDeliverTx {
 	ret := _m.Called(_a0)

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -91,7 +91,7 @@ func TestTxGossipingAndAggregation(t *testing.T) {
 
 	var wg sync.WaitGroup
 	clientNodes := 4
-	nodes, apps := createNodes(clientNodes+1, false, &wg, t)
+	nodes, apps := createNodes(clientNodes+1, &wg, t)
 
 	wg.Add((clientNodes + 1) * clientNodes)
 	for _, n := range nodes {
@@ -161,84 +161,7 @@ func TestTxGossipingAndAggregation(t *testing.T) {
 	}
 }
 
-func TestFraudProofGenerationTrigger(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-
-	var wg sync.WaitGroup
-	clientNodes := 4
-
-	nodes, apps := createNodes(clientNodes+1, true, &wg, t)
-
-	wg.Add((clientNodes + 1) * clientNodes)
-	for _, n := range nodes {
-		require.NoError(n.Start())
-	}
-
-	time.Sleep(1 * time.Second)
-
-	for i := 1; i < len(nodes); i++ {
-		data := strconv.Itoa(i) + time.Now().String()
-		require.NoError(nodes[i].P2P.GossipTx(context.TODO(), []byte(data)))
-	}
-
-	timeout := time.NewTimer(time.Second * 30)
-	doneChan := make(chan struct{})
-	go func() {
-		defer close(doneChan)
-		wg.Wait()
-	}()
-	select {
-	case <-doneChan:
-	case <-timeout.C:
-		t.FailNow()
-	}
-
-	for _, n := range nodes {
-		require.NoError(n.Stop())
-	}
-	aggApp := apps[0]
-	apps = apps[1:]
-
-	aggApp.AssertNumberOfCalls(t, "DeliverTx", clientNodes)
-	aggApp.AssertExpectations(t)
-
-	for i, app := range apps {
-		app.AssertNumberOfCalls(t, "DeliverTx", clientNodes)
-		app.AssertExpectations(t)
-
-		// assert that we have most of the blocks from aggregator
-		beginCnt := 0
-		endCnt := 0
-		commitCnt := 0
-		for _, call := range app.Calls {
-			switch call.Method {
-			case "BeginBlock":
-				beginCnt++
-			case "EndBlock":
-				endCnt++
-			case "Commit":
-				commitCnt++
-			}
-		}
-		aggregatorHeight := nodes[0].Store.Height()
-		adjustedHeight := int(aggregatorHeight - 3) // 3 is completely arbitrary
-		assert.GreaterOrEqual(beginCnt, adjustedHeight)
-		assert.GreaterOrEqual(endCnt, adjustedHeight)
-		assert.GreaterOrEqual(commitCnt, adjustedHeight)
-
-		// assert that all blocks known to node are same as produced by aggregator
-		for h := uint64(1); h <= nodes[i].Store.Height(); h++ {
-			nodeBlock, err := nodes[i].Store.LoadBlock(h)
-			require.NoError(err)
-			aggBlock, err := nodes[0].Store.LoadBlock(h)
-			require.NoError(err)
-			assert.Equal(aggBlock, nodeBlock)
-		}
-	}
-}
-
-func createNodes(num int, isAggregatorMalicious bool, wg *sync.WaitGroup, t *testing.T) ([]*Node, []*mocks.Application) {
+func createNodes(num int, wg *sync.WaitGroup, t *testing.T) ([]*Node, []*mocks.Application) {
 	t.Helper()
 
 	// create keys first, as they are required for P2P connections
@@ -252,15 +175,15 @@ func createNodes(num int, isAggregatorMalicious bool, wg *sync.WaitGroup, t *tes
 	dalc := &mockda.MockDataAvailabilityLayerClient{}
 	_ = dalc.Init(nil, store.NewDefaultInMemoryKVStore(), log.TestingLogger())
 	_ = dalc.Start()
-	nodes[0], apps[0] = createNode(0, isAggregatorMalicious, true, dalc, keys, wg, t)
+	nodes[0], apps[0] = createNode(0, true, dalc, keys, wg, t)
 	for i := 1; i < num; i++ {
-		nodes[i], apps[i] = createNode(i, isAggregatorMalicious, false, dalc, keys, wg, t)
+		nodes[i], apps[i] = createNode(i, false, dalc, keys, wg, t)
 	}
 
 	return nodes, apps
 }
 
-func createNode(n int, isMalicious bool, aggregator bool, dalc da.DataAvailabilityLayerClient, keys []crypto.PrivKey, wg *sync.WaitGroup, t *testing.T) (*Node, *mocks.Application) {
+func createNode(n int, aggregator bool, dalc da.DataAvailabilityLayerClient, keys []crypto.PrivKey, wg *sync.WaitGroup, t *testing.T) (*Node, *mocks.Application) {
 	t.Helper()
 	require := require.New(t)
 	// nodes will listen on consecutive ports on local interface
@@ -287,23 +210,13 @@ func createNode(n int, isMalicious bool, aggregator bool, dalc da.DataAvailabili
 	app := &mocks.Application{}
 	app.On("InitChain", mock.Anything).Return(abci.ResponseInitChain{})
 	app.On("CheckTx", mock.Anything).Return(abci.ResponseCheckTx{})
-	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{Events: generateEventsWithOneEventIsr(t)})
-	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{Events: generateEventsWithOneEventIsr(t)})
+	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
+	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
 	app.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
 	app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{AppHash: []byte{1, 2, 3, 4}})
-	// app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
-
-	deliverTxEvents := generateEventsWithOneEventIsr(t)
-	if isMalicious {
-		deliverTxEvents[0].Attributes[0].Value = []byte{9, 8, 7, 6}
-	}
-	app.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{Events: deliverTxEvents}).Run(func(args mock.Arguments) {
+	app.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{}).Run(func(args mock.Arguments) {
 		wg.Done()
 	})
-
-	// if isMalicious && !aggregator {
-	// 	app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
-	// }
 
 	signingKey, _, _ := crypto.GenerateEd25519Key(rand.Reader)
 	node, err := NewNode(
@@ -327,15 +240,4 @@ func createNode(n int, isMalicious bool, aggregator bool, dalc da.DataAvailabili
 	node.blockManager.SetDALC(dalc)
 
 	return node, app
-}
-
-func generateEventsWithOneEventIsr(t *testing.T) []abci.Event {
-	t.Helper()
-	return []abci.Event{{
-		Type: "isr",
-		Attributes: []abci.EventAttribute{{
-			Key:   []byte("isr"),
-			Value: []byte{1, 2, 3, 4},
-		}},
-	}}
 }

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -90,7 +90,7 @@ func TestTxGossipingAndAggregation(t *testing.T) {
 
 	var wg sync.WaitGroup
 	clientNodes := 4
-	nodes, apps := createNodes(clientNodes+1, &wg, t)
+	nodes, apps := createNodes(false, clientNodes+1, &wg, t)
 
 	wg.Add((clientNodes + 1) * clientNodes)
 	for _, n := range nodes {
@@ -160,7 +160,88 @@ func TestTxGossipingAndAggregation(t *testing.T) {
 	}
 }
 
-func createNodes(num int, wg *sync.WaitGroup, t *testing.T) ([]*Node, []*mocks.Application) {
+func TestFraudProofTrigger(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var wg sync.WaitGroup
+	clientNodes := 4
+	nodes, apps := createNodes(true, clientNodes+1, &wg, t)
+
+	wg.Add((clientNodes + 1) * clientNodes)
+	for _, n := range nodes {
+		require.NoError(n.Start())
+	}
+
+	time.Sleep(1 * time.Second)
+
+	for i := 1; i < len(nodes); i++ {
+		data := strconv.Itoa(i) + time.Now().String()
+		require.NoError(nodes[i].P2P.GossipTx(context.TODO(), []byte(data)))
+	}
+
+	timeout := time.NewTimer(time.Second * 30)
+	doneChan := make(chan struct{})
+	go func() {
+		defer close(doneChan)
+		wg.Wait()
+	}()
+	select {
+	case <-doneChan:
+	case <-timeout.C:
+		t.FailNow()
+	}
+
+	for _, n := range nodes {
+		require.NoError(n.Stop())
+	}
+	aggApp := apps[0]
+	apps = apps[1:]
+
+	aggApp.AssertNumberOfCalls(t, "DeliverTx", clientNodes)
+	aggApp.AssertExpectations(t)
+
+	for i, app := range apps {
+		app.AssertNumberOfCalls(t, "DeliverTx", clientNodes)
+		app.AssertExpectations(t)
+
+		// assert that we have most of the blocks from aggregator
+		beginCnt := 0
+		endCnt := 0
+		commitCnt := 0
+		generateFraudProofCnt := 0
+		for _, call := range app.Calls {
+			switch call.Method {
+			case "BeginBlock":
+				beginCnt++
+			case "EndBlock":
+				endCnt++
+			case "Commit":
+				commitCnt++
+			case "GenerateFraudProof":
+				generateFraudProofCnt++
+			}
+		}
+		aggregatorHeight := nodes[0].Store.Height()
+		adjustedHeight := int(aggregatorHeight - 3) // 3 is completely arbitrary
+		assert.GreaterOrEqual(beginCnt, adjustedHeight)
+		assert.GreaterOrEqual(endCnt, adjustedHeight)
+		assert.GreaterOrEqual(commitCnt, adjustedHeight)
+
+		assert.Equal(generateFraudProofCnt, beginCnt+endCnt+clientNodes)
+
+		// assert that all blocks known to node are same as produced by aggregator
+		for h := uint64(1); h <= nodes[i].Store.Height(); h++ {
+			nodeBlock, err := nodes[i].Store.LoadBlock(h)
+			require.NoError(err)
+			aggBlock, err := nodes[0].Store.LoadBlock(h)
+			require.NoError(err)
+			assert.Equal(aggBlock, nodeBlock)
+		}
+	}
+}
+
+func createNodes(isMalicious bool, num int, wg *sync.WaitGroup, t *testing.T) ([]*Node, []*mocks.Application) {
 	t.Helper()
 
 	// create keys first, as they are required for P2P connections
@@ -174,15 +255,15 @@ func createNodes(num int, wg *sync.WaitGroup, t *testing.T) ([]*Node, []*mocks.A
 	dalc := &mockda.MockDataAvailabilityLayerClient{}
 	_ = dalc.Init(nil, store.NewDefaultInMemoryKVStore(), log.TestingLogger())
 	_ = dalc.Start()
-	nodes[0], apps[0] = createNode(0, true, dalc, keys, wg, t)
+	nodes[0], apps[0] = createNode(0, isMalicious, true, dalc, keys, wg, t)
 	for i := 1; i < num; i++ {
-		nodes[i], apps[i] = createNode(i, false, dalc, keys, wg, t)
+		nodes[i], apps[i] = createNode(i, isMalicious, false, dalc, keys, wg, t)
 	}
 
 	return nodes, apps
 }
 
-func createNode(n int, aggregator bool, dalc da.DataAvailabilityLayerClient, keys []crypto.PrivKey, wg *sync.WaitGroup, t *testing.T) (*Node, *mocks.Application) {
+func createNode(n int, isMalicious bool, aggregator bool, dalc da.DataAvailabilityLayerClient, keys []crypto.PrivKey, wg *sync.WaitGroup, t *testing.T) (*Node, *mocks.Application) {
 	t.Helper()
 	require := require.New(t)
 	// nodes will listen on consecutive ports on local interface
@@ -212,7 +293,15 @@ func createNode(n int, aggregator bool, dalc da.DataAvailabilityLayerClient, key
 	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
 	app.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
-	app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{AppHash: []byte{1, 2, 3, 4}})
+	if isMalicious && aggregator {
+		app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{AppHash: []byte{9, 8, 7, 6}})
+	} else {
+		app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{AppHash: []byte{1, 2, 3, 4}})
+	}
+
+	if isMalicious && !aggregator {
+		app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
+	}
 	app.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{}).Run(func(args mock.Arguments) {
 		wg.Done()
 	})

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -205,7 +205,6 @@ func TestFraudProofGenerationTrigger(t *testing.T) {
 
 	for i, app := range apps {
 		app.AssertNumberOfCalls(t, "DeliverTx", clientNodes)
-		app.AssertNumberOfCalls(t, "GenerateFraudProof", 1)
 		app.AssertExpectations(t)
 
 		// assert that we have most of the blocks from aggregator
@@ -291,8 +290,8 @@ func createNode(n int, isMalicious bool, aggregator bool, dalc da.DataAvailabili
 	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{Events: generateEventsWithOneEventIsr(t)})
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{Events: generateEventsWithOneEventIsr(t)})
 	app.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
-	app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{})
-	app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
+	app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{AppHash: []byte{1, 2, 3, 4}})
+	// app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
 
 	deliverTxEvents := generateEventsWithOneEventIsr(t)
 	if isMalicious {
@@ -302,9 +301,9 @@ func createNode(n int, isMalicious bool, aggregator bool, dalc da.DataAvailabili
 		wg.Done()
 	})
 
-	if isMalicious && !aggregator {
-		app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
-	}
+	// if isMalicious && !aggregator {
+	// 	app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
+	// }
 
 	signingKey, _, _ := crypto.GenerateEd25519Key(rand.Reader)
 	node, err := NewNode(

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -40,6 +40,8 @@ func TestAggregatorMode(t *testing.T) {
 	app.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{})
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
 	app.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
+	app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{})
+	app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
 
 	key, _, _ := crypto.GenerateEd25519Key(rand.Reader)
 	signingKey, _, _ := crypto.GenerateEd25519Key(rand.Reader)
@@ -289,6 +291,8 @@ func createNode(n int, isMalicious bool, aggregator bool, dalc da.DataAvailabili
 	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{Events: generateEventsWithOneEventIsr(t)})
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{Events: generateEventsWithOneEventIsr(t)})
 	app.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
+	app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{})
+	app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
 
 	deliverTxEvents := generateEventsWithOneEventIsr(t)
 	if isMalicious {

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -41,7 +41,6 @@ func TestAggregatorMode(t *testing.T) {
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
 	app.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
 	app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{})
-	app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
 
 	key, _, _ := crypto.GenerateEd25519Key(rand.Reader)
 	signingKey, _, _ := crypto.GenerateEd25519Key(rand.Reader)

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -209,7 +209,7 @@ func TestFraudProofTrigger(t *testing.T) {
 		beginCnt := 0
 		endCnt := 0
 		commitCnt := 0
-		generateFraudProofCnt := 0
+		triggerFraudProofGenerationModeCnt := 0
 		for _, call := range app.Calls {
 			switch call.Method {
 			case "BeginBlock":
@@ -218,8 +218,8 @@ func TestFraudProofTrigger(t *testing.T) {
 				endCnt++
 			case "Commit":
 				commitCnt++
-			case "GenerateFraudProof":
-				generateFraudProofCnt++
+			case "TriggerFraudProofGenerationMode":
+				triggerFraudProofGenerationModeCnt++
 			}
 		}
 		aggregatorHeight := nodes[0].Store.Height()
@@ -228,7 +228,7 @@ func TestFraudProofTrigger(t *testing.T) {
 		assert.GreaterOrEqual(endCnt, adjustedHeight)
 		assert.GreaterOrEqual(commitCnt, adjustedHeight)
 
-		assert.Equal(generateFraudProofCnt, beginCnt+endCnt+clientNodes)
+		assert.Equal(triggerFraudProofGenerationModeCnt, beginCnt+endCnt+clientNodes)
 
 		// assert that all blocks known to node are same as produced by aggregator
 		for h := uint64(1); h <= nodes[i].Store.Height(); h++ {
@@ -300,7 +300,7 @@ func createNode(n int, isMalicious bool, aggregator bool, dalc da.DataAvailabili
 	}
 
 	if isMalicious && !aggregator {
-		app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
+		app.On("TriggerFraudProofGenerationMode", mock.Anything).Return(abci.ResponseTriggerFraudProofGenerationMode{})
 	}
 	app.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{}).Run(func(args mock.Arguments) {
 		wg.Done()

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -36,6 +36,9 @@ message Request {
     RequestOfferSnapshot      offer_snapshot       = 13;
     RequestLoadSnapshotChunk  load_snapshot_chunk  = 14;
     RequestApplySnapshotChunk apply_snapshot_chunk = 15;
+    RequestGetAppHash         get_app_hash         = 16;
+    RequestGenerateFraudProof generate_fraud_proof = 17;
+    RequestTriggerFraudProofGenerationMode trigger_fraud_proof_generation_mode = 18;
   }
 }
 
@@ -102,8 +105,7 @@ message RequestEndBlock {
 message RequestCommit {}
 
 // lists available snapshots
-message RequestListSnapshots {
-}
+message RequestListSnapshots {}
 
 // offers a snapshot to the application
 message RequestOfferSnapshot {
@@ -124,6 +126,15 @@ message RequestApplySnapshotChunk {
   bytes  chunk  = 2;
   string sender = 3;
 }
+
+// Gets the current appHash
+message RequestGetAppHash {}
+
+// Generates a fraud proof
+message RequestGenerateFraudProof {}
+
+// Triggers fraud proof generation mode
+message RequestTriggerFraudProofGenerationMode {}
 
 //----------------------------------------
 // Response types
@@ -146,6 +157,9 @@ message Response {
     ResponseOfferSnapshot      offer_snapshot       = 14;
     ResponseLoadSnapshotChunk  load_snapshot_chunk  = 15;
     ResponseApplySnapshotChunk apply_snapshot_chunk = 16;
+    ResponseGetAppHash         get_app_hash         = 17;
+    ResponseGenerateFraudProof generate_fraud_proof = 18;
+    ResponseTriggerFraudProofGenerationMode trigger_fraud_proof_generation_mode = 19;
   }
 }
 
@@ -212,6 +226,12 @@ message ResponseCheckTx {
   repeated Event events     = 7
       [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
   string codespace = 8;
+  string sender    = 9;
+  int64  priority  = 10;
+
+  // mempool_error is set by Tendermint.
+  // ABCI applictions creating a ResponseCheckTX should not set mempool_error.
+  string mempool_error = 11;
 }
 
 message ResponseDeliverTx {
@@ -221,16 +241,17 @@ message ResponseDeliverTx {
   string         info       = 4;  // nondeterministic
   int64          gas_wanted = 5 [json_name = "gas_wanted"];
   int64          gas_used   = 6 [json_name = "gas_used"];
-  repeated Event events     = 7
-      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"]; // nondeterministic
+  repeated Event events     = 7 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag)  = "events,omitempty"
+  ];  // nondeterministic
   string codespace = 8;
 }
 
 message ResponseEndBlock {
-  repeated ValidatorUpdate validator_updates = 1
-      [(gogoproto.nullable) = false];
-  ConsensusParams consensus_param_updates = 2;
-  repeated Event  events                  = 3
+  repeated ValidatorUpdate validator_updates       = 1 [(gogoproto.nullable) = false];
+  ConsensusParams          consensus_param_updates = 2;
+  repeated Event           events                  = 3
       [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
 }
 
@@ -274,6 +295,18 @@ message ResponseApplySnapshotChunk {
     RETRY_SNAPSHOT  = 4;  // Retry snapshot (combine with refetch and reject)
     REJECT_SNAPSHOT = 5;  // Reject this snapshot, try others
   }
+}
+
+message ResponseGetAppHash {
+  bytes app_hash = 1;
+}
+
+message ResponseGenerateFraudProof {
+  FraudProof fraudProof = 1;
+}
+
+message ResponseTriggerFraudProofGenerationMode {
+  bool success = 1;
 }
 
 //----------------------------------------
@@ -364,10 +397,8 @@ message Evidence {
   // The height when the offense occurred
   int64 height = 3;
   // The corresponding time where the offense occurred
-  google.protobuf.Timestamp time = 4 [
-    (gogoproto.nullable) = false,
-    (gogoproto.stdtime)  = true
-  ];
+  google.protobuf.Timestamp time = 4
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
   // Total voting power of the validator set in case the ABCI application does
   // not store historical validators.
   // https://github.com/tendermint/tendermint/issues/4581
@@ -383,6 +414,30 @@ message Snapshot {
   uint32 chunks   = 3;  // Number of chunks in the snapshot
   bytes  hash     = 4;  // Arbitrary snapshot hash, equal only if identical
   bytes  metadata = 5;  // Arbitrary application metadata
+}
+
+// Represents a single-round fraudProof
+message FraudProof {
+  int64 block_height = 1;
+  bytes appHash = 2;
+  map<string, StateWitness> stateWitness = 3;
+}
+
+// State witness with a list of all witness data
+message StateWitness {
+  // store level proof
+  tendermint.crypto.ProofOp proof_op = 1;
+  // substore level hash
+  bytes rootHash = 2;
+  // List of witness data
+  repeated WitnessData witnessData = 3;
+}
+
+// Witness data containing a key/value pair and a SMT proof for said key/value pair
+message WitnessData {
+  bytes key = 1;
+  bytes value = 2;
+  tendermint.crypto.ProofOp proof = 3;
 }
 
 //----------------------------------------
@@ -402,6 +457,11 @@ service ABCIApplication {
   rpc EndBlock(RequestEndBlock) returns (ResponseEndBlock);
   rpc ListSnapshots(RequestListSnapshots) returns (ResponseListSnapshots);
   rpc OfferSnapshot(RequestOfferSnapshot) returns (ResponseOfferSnapshot);
-  rpc LoadSnapshotChunk(RequestLoadSnapshotChunk) returns (ResponseLoadSnapshotChunk);
-  rpc ApplySnapshotChunk(RequestApplySnapshotChunk) returns (ResponseApplySnapshotChunk);
+  rpc LoadSnapshotChunk(RequestLoadSnapshotChunk)
+      returns (ResponseLoadSnapshotChunk);
+  rpc ApplySnapshotChunk(RequestApplySnapshotChunk)
+      returns (ResponseApplySnapshotChunk);
+  rpc GetAppHash(RequestGetAppHash) returns (ResponseGetAppHash);
+  rpc GenerateFraudProof(RequestGenerateFraudProof) returns (ResponseGenerateFraudProof);
+  rpc TriggerFraudProofGenerationMode(RequestTriggerFraudProofGenerationMode) returns (ResponseTriggerFraudProofGenerationMode);
 }

--- a/rpc/client/client_test.go
+++ b/rpc/client/client_test.go
@@ -421,7 +421,7 @@ func TestTx(t *testing.T) {
 	mockApp.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{})
 	mockApp.On("CheckTx", mock.Anything).Return(abci.ResponseCheckTx{})
 	mockApp.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{})
-	mockApp.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
+	mockApp.On("TriggerFraudProofGenerationMode", mock.Anything).Return(abci.ResponseTriggerFraudProofGenerationMode{})
 
 	err = rpc.node.Start()
 	require.NoError(err)
@@ -636,7 +636,7 @@ func TestValidatorSetHandling(t *testing.T) {
 	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
 	app.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
 	app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{})
-	app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
+	app.On("TriggerFraudProofGenerationMode", mock.Anything).Return(abci.ResponseTriggerFraudProofGenerationMode{})
 
 	key, _, _ := crypto.GenerateEd25519Key(crand.Reader)
 	signingKey, _, _ := crypto.GenerateEd25519Key(crand.Reader)

--- a/rpc/client/client_test.go
+++ b/rpc/client/client_test.go
@@ -420,6 +420,8 @@ func TestTx(t *testing.T) {
 	mockApp.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
 	mockApp.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{})
 	mockApp.On("CheckTx", mock.Anything).Return(abci.ResponseCheckTx{})
+	mockApp.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{})
+	mockApp.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
 
 	err = rpc.node.Start()
 	require.NoError(err)
@@ -633,6 +635,8 @@ func TestValidatorSetHandling(t *testing.T) {
 	app.On("CheckTx", mock.Anything).Return(abci.ResponseCheckTx{})
 	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
 	app.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
+	app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{})
+	app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
 
 	key, _, _ := crypto.GenerateEd25519Key(crand.Reader)
 	signingKey, _, _ := crypto.GenerateEd25519Key(crand.Reader)

--- a/rpc/json/service_test.go
+++ b/rpc/json/service_test.go
@@ -275,6 +275,8 @@ func getRPC(t *testing.T) (*mocks.Application, *client.Client) {
 	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
 	app.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
+	app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{})
+	app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
 	app.On("CheckTx", mock.Anything).Return(abci.ResponseCheckTx{
 		GasWanted: 1000,
 		GasUsed:   1000,

--- a/state/executor.go
+++ b/state/executor.go
@@ -284,19 +284,19 @@ func (e *BlockExecutor) execute(ctx context.Context, state types.State, block *t
 		if r, ok := res.Value.(*abci.Response_DeliverTx); ok {
 			txRes := r.DeliverTx
 
-			if currentIsrs != nil {
-				generatedIsr, err := e.getAppHash()
-				if err != nil {
-					return
-				}
-				deliverTxIsr := currentIsrs[currentIsrIndex]
-				currentIsrIndex++
-				if !bytes.Equal(deliverTxIsr, generatedIsr) {
-					e.logger.Debug("ISR Mismatch", "given_isr", deliverTxIsr, "generated_isr", generatedIsr)
-					_ = req.Value.(*abci.Request_DeliverTx).DeliverTx.Tx
-					go e.proxyApp.GenerateFraudProofSync(abci.RequestGenerateFraudProof{})
-				}
-			}
+			// if currentIsrs != nil {
+			// 	generatedIsr, err := e.getAppHash()
+			// 	if err != nil {
+			// 		return
+			// 	}
+			// 	deliverTxIsr := currentIsrs[currentIsrIndex]
+			// 	currentIsrIndex++
+			// 	if !bytes.Equal(deliverTxIsr, generatedIsr) {
+			// 		e.logger.Debug("ISR Mismatch", "given_isr", deliverTxIsr, "generated_isr", generatedIsr)
+			// 		_ = req.Value.(*abci.Request_DeliverTx).DeliverTx.Tx
+			// 		go e.proxyApp.GenerateFraudProofSync(abci.RequestGenerateFraudProof{})
+			// 	}
+			// }
 
 			if txRes.Code == abci.CodeTypeOK {
 				validTxs++

--- a/state/executor.go
+++ b/state/executor.go
@@ -368,7 +368,7 @@ func (e *BlockExecutor) checkFraudProofTrigger(generatedIsr []byte, currentIsrs 
 		stateIsr := currentIsrs[index]
 		if !bytes.Equal(stateIsr, generatedIsr) {
 			e.logger.Debug("ISR Mismatch", "given_isr", stateIsr, "generated_isr", generatedIsr)
-			_, err := e.proxyApp.GenerateFraudProofSync(abci.RequestGenerateFraudProof{})
+			_, err := e.proxyApp.TriggerFraudProofGenerationModeSync(abci.RequestTriggerFraudProofGenerationMode{})
 			if err != nil {
 				return err
 			}

--- a/state/executor.go
+++ b/state/executor.go
@@ -359,7 +359,7 @@ func (e *BlockExecutor) checkFraudProofTrigger(generatedIsr []byte, currentIsrs 
 		stateIsr := currentIsrs[index]
 		if !bytes.Equal(stateIsr, generatedIsr) {
 			e.logger.Debug("ISR Mismatch", "given_isr", stateIsr, "generated_isr", generatedIsr)
-			go e.proxyApp.GenerateFraudProofSync(abci.RequestGenerateFraudProof{})
+			e.proxyApp.GenerateFraudProofSync(abci.RequestGenerateFraudProof{})
 		}
 	}
 }

--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -80,6 +80,8 @@ func TestApplyBlock(t *testing.T) {
 	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
 	app.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{})
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
+	app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{})
+	app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
 	var mockAppHash [32]byte
 	_, err := rand.Read(mockAppHash[:])
 	require.NoError(err)

--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -80,7 +80,7 @@ func TestApplyBlock(t *testing.T) {
 	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
 	app.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{})
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
-	app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
+	app.On("TriggerFraudProofGenerationMode", mock.Anything).Return(abci.ResponseTriggerFraudProofGenerationMode{})
 	var mockAppHash [32]byte
 	_, err := rand.Read(mockAppHash[:])
 	require.NoError(err)

--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -80,11 +80,13 @@ func TestApplyBlock(t *testing.T) {
 	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
 	app.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{})
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
-	app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{})
 	app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
 	var mockAppHash [32]byte
 	_, err := rand.Read(mockAppHash[:])
 	require.NoError(err)
+	app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{
+		AppHash: mockAppHash[:],
+	})
 	app.On("Commit", mock.Anything).Return(abci.ResponseCommit{
 		Data: mockAppHash[:],
 	})


### PR DESCRIPTION
An Optimint full node must compare the ISRs it generates when verifying state transitons (see https://github.com/celestiaorg/cosmos-sdk/issues/127) with those it receives from the block producer. 

In the event that there is a mismatch the node should generate a fraud proof. 

Uses the version of tendermint with added ABCI methods here: https://github.com/celestiaorg/tendermint/pull/4 so build tests do not work

Resolves: https://github.com/celestiaorg/optimint/issues/385