### PR TITLE
feat: Generate fraud proof after trigger

### DIFF
--- a/mocks/Application.go
+++ b/mocks/Application.go
@@ -96,21 +96,6 @@ func (_m *Application) GetAppHash(_a0 types.RequestGetAppHash) types.ResponseGet
 	return r0
 }
 
-// Commit provides a mock function with given fields:
-func (_m *Application) TriggerFraudProofGenerationMode(_a0 types.RequestTriggerFraudProofGenerationMode) types.ResponseTriggerFraudProofGenerationMode {
-	ret := _m.Called(_a0)
-
-	var r0 types.ResponseTriggerFraudProofGenerationMode
-	if rf, ok := ret.Get(0).(func(types.RequestTriggerFraudProofGenerationMode) types.ResponseTriggerFraudProofGenerationMode); ok {
-		r0 = rf(_a0)
-	} else {
-		r0 = ret.Get(0).(types.ResponseTriggerFraudProofGenerationMode)
-	}
-
-	return r0
-}
-
-
 // DeliverTx provides a mock function with given fields: _a0
 func (_m *Application) DeliverTx(_a0 types.RequestDeliverTx) types.ResponseDeliverTx {
 	ret := _m.Called(_a0)

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -209,7 +209,7 @@ func TestFraudProofTrigger(t *testing.T) {
 		beginCnt := 0
 		endCnt := 0
 		commitCnt := 0
-		triggerFraudProofGenerationModeCnt := 0
+		generateFraudProofCnt := 0
 		for _, call := range app.Calls {
 			switch call.Method {
 			case "BeginBlock":
@@ -218,8 +218,8 @@ func TestFraudProofTrigger(t *testing.T) {
 				endCnt++
 			case "Commit":
 				commitCnt++
-			case "TriggerFraudProofGenerationMode":
-				triggerFraudProofGenerationModeCnt++
+			case "GenerateFraudProof":
+				generateFraudProofCnt++
 			}
 		}
 		aggregatorHeight := nodes[0].Store.Height()
@@ -228,7 +228,7 @@ func TestFraudProofTrigger(t *testing.T) {
 		assert.GreaterOrEqual(endCnt, adjustedHeight)
 		assert.GreaterOrEqual(commitCnt, adjustedHeight)
 
-		assert.Equal(triggerFraudProofGenerationModeCnt, beginCnt+endCnt+clientNodes)
+		assert.Equal(generateFraudProofCnt, beginCnt+endCnt+clientNodes)
 
 		// assert that all blocks known to node are same as produced by aggregator
 		for h := uint64(1); h <= nodes[i].Store.Height(); h++ {
@@ -300,7 +300,7 @@ func createNode(n int, isMalicious bool, aggregator bool, dalc da.DataAvailabili
 	}
 
 	if isMalicious && !aggregator {
-		app.On("TriggerFraudProofGenerationMode", mock.Anything).Return(abci.ResponseTriggerFraudProofGenerationMode{})
+		app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{FraudProof: &abci.FraudProof{}})
 	}
 	app.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{}).Run(func(args mock.Arguments) {
 		wg.Done()

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -38,6 +38,7 @@ message Request {
     RequestApplySnapshotChunk apply_snapshot_chunk = 15;
     RequestGetAppHash         get_app_hash         = 16;
     RequestGenerateFraudProof generate_fraud_proof = 17;
+    RequestVerifyFraudProof   verify_fraud_proof   = 18;
   }
 }
 
@@ -136,6 +137,12 @@ message RequestGenerateFraudProof {
   RequestEndBlock endBlockRequest = 3;
 }
 
+// Verifies a fraud proof
+message RequestVerifyFraudProof {
+  FraudProof fraud_proof = 1;
+  bytes expected_app_hash = 2;
+}
+
 //----------------------------------------
 // Response types
 
@@ -159,6 +166,7 @@ message Response {
     ResponseApplySnapshotChunk apply_snapshot_chunk = 16;
     ResponseGetAppHash         get_app_hash         = 17;
     ResponseGenerateFraudProof generate_fraud_proof = 18;
+    ResponseVerifyFraudProof   verify_fraud_proof   = 19;
   }
 }
 
@@ -304,6 +312,10 @@ message ResponseGenerateFraudProof {
   FraudProof fraud_proof = 1;
 }
 
+message ResponseVerifyFraudProof {
+  bool success = 1;
+}
+
 //----------------------------------------
 // Misc.
 
@@ -416,6 +428,10 @@ message FraudProof {
   int64 block_height = 1;
   bytes app_hash = 2;
   map<string, StateWitness> state_witness = 3;
+
+  RequestBeginBlock fraudulentBeginBlock = 4;
+  RequestDeliverTx fraudulentDeliverTx = 5;
+  RequestEndBlock fraudulentEndBlock = 6;
 }
 
 // State witness with a list of all witness data
@@ -458,4 +474,5 @@ service ABCIApplication {
       returns (ResponseApplySnapshotChunk);
   rpc GetAppHash(RequestGetAppHash) returns (ResponseGetAppHash);
   rpc GenerateFraudProof(RequestGenerateFraudProof) returns (ResponseGenerateFraudProof);
+  rpc VerifyFraudProof(RequestVerifyFraudProof) returns (ResponseVerifyFraudProof);
 }

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -36,6 +36,8 @@ message Request {
     RequestOfferSnapshot      offer_snapshot       = 13;
     RequestLoadSnapshotChunk  load_snapshot_chunk  = 14;
     RequestApplySnapshotChunk apply_snapshot_chunk = 15;
+    RequestGetAppHash         get_app_hash         = 16;
+    RequestGenerateFraudProof generate_fraud_proof = 17;
   }
 }
 
@@ -102,8 +104,7 @@ message RequestEndBlock {
 message RequestCommit {}
 
 // lists available snapshots
-message RequestListSnapshots {
-}
+message RequestListSnapshots {}
 
 // offers a snapshot to the application
 message RequestOfferSnapshot {
@@ -123,6 +124,16 @@ message RequestApplySnapshotChunk {
   uint32 index  = 1;
   bytes  chunk  = 2;
   string sender = 3;
+}
+
+// Gets the current appHash
+message RequestGetAppHash {}
+
+// Generates a fraud proof
+message RequestGenerateFraudProof {
+  RequestBeginBlock beginBlockRequest = 1 [(gogoproto.nullable) = false];
+  repeated RequestDeliverTx deliverTxRequests = 2;
+  RequestEndBlock endBlockRequest = 3;
 }
 
 //----------------------------------------
@@ -146,6 +157,8 @@ message Response {
     ResponseOfferSnapshot      offer_snapshot       = 14;
     ResponseLoadSnapshotChunk  load_snapshot_chunk  = 15;
     ResponseApplySnapshotChunk apply_snapshot_chunk = 16;
+    ResponseGetAppHash         get_app_hash         = 17;
+    ResponseGenerateFraudProof generate_fraud_proof = 18;
   }
 }
 
@@ -212,6 +225,12 @@ message ResponseCheckTx {
   repeated Event events     = 7
       [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
   string codespace = 8;
+  string sender    = 9;
+  int64  priority  = 10;
+
+  // mempool_error is set by Tendermint.
+  // ABCI applictions creating a ResponseCheckTX should not set mempool_error.
+  string mempool_error = 11;
 }
 
 message ResponseDeliverTx {
@@ -221,16 +240,17 @@ message ResponseDeliverTx {
   string         info       = 4;  // nondeterministic
   int64          gas_wanted = 5 [json_name = "gas_wanted"];
   int64          gas_used   = 6 [json_name = "gas_used"];
-  repeated Event events     = 7
-      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"]; // nondeterministic
+  repeated Event events     = 7 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag)  = "events,omitempty"
+  ];  // nondeterministic
   string codespace = 8;
 }
 
 message ResponseEndBlock {
-  repeated ValidatorUpdate validator_updates = 1
-      [(gogoproto.nullable) = false];
-  ConsensusParams consensus_param_updates = 2;
-  repeated Event  events                  = 3
+  repeated ValidatorUpdate validator_updates       = 1 [(gogoproto.nullable) = false];
+  ConsensusParams          consensus_param_updates = 2;
+  repeated Event           events                  = 3
       [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
 }
 
@@ -274,6 +294,14 @@ message ResponseApplySnapshotChunk {
     RETRY_SNAPSHOT  = 4;  // Retry snapshot (combine with refetch and reject)
     REJECT_SNAPSHOT = 5;  // Reject this snapshot, try others
   }
+}
+
+message ResponseGetAppHash {
+  bytes app_hash = 1;
+}
+
+message ResponseGenerateFraudProof {
+  FraudProof fraud_proof = 1;
 }
 
 //----------------------------------------
@@ -364,10 +392,8 @@ message Evidence {
   // The height when the offense occurred
   int64 height = 3;
   // The corresponding time where the offense occurred
-  google.protobuf.Timestamp time = 4 [
-    (gogoproto.nullable) = false,
-    (gogoproto.stdtime)  = true
-  ];
+  google.protobuf.Timestamp time = 4
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
   // Total voting power of the validator set in case the ABCI application does
   // not store historical validators.
   // https://github.com/tendermint/tendermint/issues/4581
@@ -383,6 +409,30 @@ message Snapshot {
   uint32 chunks   = 3;  // Number of chunks in the snapshot
   bytes  hash     = 4;  // Arbitrary snapshot hash, equal only if identical
   bytes  metadata = 5;  // Arbitrary application metadata
+}
+
+// Represents a single-round fraudProof
+message FraudProof {
+  int64 block_height = 1;
+  bytes app_hash = 2;
+  map<string, StateWitness> state_witness = 3;
+}
+
+// State witness with a list of all witness data
+message StateWitness {
+  // store level proof
+  tendermint.crypto.ProofOp proof_op = 1;
+  // substore level hash
+  bytes root_hash = 2;
+  // List of witness data
+  repeated WitnessData witness_data = 3;
+}
+
+// Witness data containing a key/value pair and a SMT proof for said key/value pair
+message WitnessData {
+  bytes key = 1;
+  bytes value = 2;
+  tendermint.crypto.ProofOp proof = 3;
 }
 
 //----------------------------------------
@@ -402,6 +452,10 @@ service ABCIApplication {
   rpc EndBlock(RequestEndBlock) returns (ResponseEndBlock);
   rpc ListSnapshots(RequestListSnapshots) returns (ResponseListSnapshots);
   rpc OfferSnapshot(RequestOfferSnapshot) returns (ResponseOfferSnapshot);
-  rpc LoadSnapshotChunk(RequestLoadSnapshotChunk) returns (ResponseLoadSnapshotChunk);
-  rpc ApplySnapshotChunk(RequestApplySnapshotChunk) returns (ResponseApplySnapshotChunk);
+  rpc LoadSnapshotChunk(RequestLoadSnapshotChunk)
+      returns (ResponseLoadSnapshotChunk);
+  rpc ApplySnapshotChunk(RequestApplySnapshotChunk)
+      returns (ResponseApplySnapshotChunk);
+  rpc GetAppHash(RequestGetAppHash) returns (ResponseGetAppHash);
+  rpc GenerateFraudProof(RequestGenerateFraudProof) returns (ResponseGenerateFraudProof);
 }

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -36,9 +36,6 @@ message Request {
     RequestOfferSnapshot      offer_snapshot       = 13;
     RequestLoadSnapshotChunk  load_snapshot_chunk  = 14;
     RequestApplySnapshotChunk apply_snapshot_chunk = 15;
-    RequestGetAppHash         get_app_hash         = 16;
-    RequestGenerateFraudProof generate_fraud_proof = 17;
-    RequestTriggerFraudProofGenerationMode trigger_fraud_proof_generation_mode = 18;
   }
 }
 
@@ -105,7 +102,8 @@ message RequestEndBlock {
 message RequestCommit {}
 
 // lists available snapshots
-message RequestListSnapshots {}
+message RequestListSnapshots {
+}
 
 // offers a snapshot to the application
 message RequestOfferSnapshot {
@@ -126,15 +124,6 @@ message RequestApplySnapshotChunk {
   bytes  chunk  = 2;
   string sender = 3;
 }
-
-// Gets the current appHash
-message RequestGetAppHash {}
-
-// Generates a fraud proof
-message RequestGenerateFraudProof {}
-
-// Triggers fraud proof generation mode
-message RequestTriggerFraudProofGenerationMode {}
 
 //----------------------------------------
 // Response types
@@ -157,9 +146,6 @@ message Response {
     ResponseOfferSnapshot      offer_snapshot       = 14;
     ResponseLoadSnapshotChunk  load_snapshot_chunk  = 15;
     ResponseApplySnapshotChunk apply_snapshot_chunk = 16;
-    ResponseGetAppHash         get_app_hash         = 17;
-    ResponseGenerateFraudProof generate_fraud_proof = 18;
-    ResponseTriggerFraudProofGenerationMode trigger_fraud_proof_generation_mode = 19;
   }
 }
 
@@ -226,12 +212,6 @@ message ResponseCheckTx {
   repeated Event events     = 7
       [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
   string codespace = 8;
-  string sender    = 9;
-  int64  priority  = 10;
-
-  // mempool_error is set by Tendermint.
-  // ABCI applictions creating a ResponseCheckTX should not set mempool_error.
-  string mempool_error = 11;
 }
 
 message ResponseDeliverTx {
@@ -241,17 +221,16 @@ message ResponseDeliverTx {
   string         info       = 4;  // nondeterministic
   int64          gas_wanted = 5 [json_name = "gas_wanted"];
   int64          gas_used   = 6 [json_name = "gas_used"];
-  repeated Event events     = 7 [
-    (gogoproto.nullable) = false,
-    (gogoproto.jsontag)  = "events,omitempty"
-  ];  // nondeterministic
+  repeated Event events     = 7
+      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"]; // nondeterministic
   string codespace = 8;
 }
 
 message ResponseEndBlock {
-  repeated ValidatorUpdate validator_updates       = 1 [(gogoproto.nullable) = false];
-  ConsensusParams          consensus_param_updates = 2;
-  repeated Event           events                  = 3
+  repeated ValidatorUpdate validator_updates = 1
+      [(gogoproto.nullable) = false];
+  ConsensusParams consensus_param_updates = 2;
+  repeated Event  events                  = 3
       [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
 }
 
@@ -295,18 +274,6 @@ message ResponseApplySnapshotChunk {
     RETRY_SNAPSHOT  = 4;  // Retry snapshot (combine with refetch and reject)
     REJECT_SNAPSHOT = 5;  // Reject this snapshot, try others
   }
-}
-
-message ResponseGetAppHash {
-  bytes app_hash = 1;
-}
-
-message ResponseGenerateFraudProof {
-  FraudProof fraudProof = 1;
-}
-
-message ResponseTriggerFraudProofGenerationMode {
-  bool success = 1;
 }
 
 //----------------------------------------
@@ -397,8 +364,10 @@ message Evidence {
   // The height when the offense occurred
   int64 height = 3;
   // The corresponding time where the offense occurred
-  google.protobuf.Timestamp time = 4
-      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  google.protobuf.Timestamp time = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.stdtime)  = true
+  ];
   // Total voting power of the validator set in case the ABCI application does
   // not store historical validators.
   // https://github.com/tendermint/tendermint/issues/4581
@@ -414,30 +383,6 @@ message Snapshot {
   uint32 chunks   = 3;  // Number of chunks in the snapshot
   bytes  hash     = 4;  // Arbitrary snapshot hash, equal only if identical
   bytes  metadata = 5;  // Arbitrary application metadata
-}
-
-// Represents a single-round fraudProof
-message FraudProof {
-  int64 block_height = 1;
-  bytes appHash = 2;
-  map<string, StateWitness> stateWitness = 3;
-}
-
-// State witness with a list of all witness data
-message StateWitness {
-  // store level proof
-  tendermint.crypto.ProofOp proof_op = 1;
-  // substore level hash
-  bytes rootHash = 2;
-  // List of witness data
-  repeated WitnessData witnessData = 3;
-}
-
-// Witness data containing a key/value pair and a SMT proof for said key/value pair
-message WitnessData {
-  bytes key = 1;
-  bytes value = 2;
-  tendermint.crypto.ProofOp proof = 3;
 }
 
 //----------------------------------------
@@ -457,11 +402,6 @@ service ABCIApplication {
   rpc EndBlock(RequestEndBlock) returns (ResponseEndBlock);
   rpc ListSnapshots(RequestListSnapshots) returns (ResponseListSnapshots);
   rpc OfferSnapshot(RequestOfferSnapshot) returns (ResponseOfferSnapshot);
-  rpc LoadSnapshotChunk(RequestLoadSnapshotChunk)
-      returns (ResponseLoadSnapshotChunk);
-  rpc ApplySnapshotChunk(RequestApplySnapshotChunk)
-      returns (ResponseApplySnapshotChunk);
-  rpc GetAppHash(RequestGetAppHash) returns (ResponseGetAppHash);
-  rpc GenerateFraudProof(RequestGenerateFraudProof) returns (ResponseGenerateFraudProof);
-  rpc TriggerFraudProofGenerationMode(RequestTriggerFraudProofGenerationMode) returns (ResponseTriggerFraudProofGenerationMode);
+  rpc LoadSnapshotChunk(RequestLoadSnapshotChunk) returns (ResponseLoadSnapshotChunk);
+  rpc ApplySnapshotChunk(RequestApplySnapshotChunk) returns (ResponseApplySnapshotChunk);
 }

--- a/proto/tendermint/version/types.proto
+++ b/proto/tendermint/version/types.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+package tendermint.version;
+
+option go_package = "github.com/tendermint/tendermint/proto/tendermint/version";
+
+import "gogoproto/gogo.proto";
+
+// App includes the protocol and software version for the application.
+// This information is included in ResponseInfo. The App.Protocol can be
+// updated in ResponseEndBlock.
+message App {
+  uint64 protocol = 1;
+  string software = 2;
+}
+
+// Consensus captures the consensus rules for processing a block in the blockchain,
+// including all blockchain data structures and the rules of the application's
+// state transition machine.
+message Consensus {
+  option (gogoproto.equal) = true;
+
+  uint64 block = 1;
+  uint64 app   = 2;
+}

--- a/rpc/client/client_test.go
+++ b/rpc/client/client_test.go
@@ -421,7 +421,7 @@ func TestTx(t *testing.T) {
 	mockApp.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{})
 	mockApp.On("CheckTx", mock.Anything).Return(abci.ResponseCheckTx{})
 	mockApp.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{})
-	mockApp.On("TriggerFraudProofGenerationMode", mock.Anything).Return(abci.ResponseTriggerFraudProofGenerationMode{})
+	mockApp.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
 
 	err = rpc.node.Start()
 	require.NoError(err)
@@ -636,7 +636,7 @@ func TestValidatorSetHandling(t *testing.T) {
 	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
 	app.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
 	app.On("GetAppHash", mock.Anything).Return(abci.ResponseGetAppHash{})
-	app.On("TriggerFraudProofGenerationMode", mock.Anything).Return(abci.ResponseTriggerFraudProofGenerationMode{})
+	app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
 
 	key, _, _ := crypto.GenerateEd25519Key(crand.Reader)
 	signingKey, _, _ := crypto.GenerateEd25519Key(crand.Reader)

--- a/state/executor.go
+++ b/state/executor.go
@@ -326,7 +326,7 @@ func (e *BlockExecutor) execute(ctx context.Context, state types.State, block *t
 	currentIsrIndex++
 
 	if isFraud {
-		// TODO: catch up app and call generate fraudproof, then gossip it to P2P network
+		// TODO: call generate fraudproof, fraudTx: BeginBlock
 	}
 
 	for _, tx := range block.Data.Txs {
@@ -345,7 +345,8 @@ func (e *BlockExecutor) execute(ctx context.Context, state types.State, block *t
 		}
 		currentIsrIndex++
 		if isFraud {
-			// TODO: catch up app and call generate fraudproof, then gossip it to P2P network
+			// TODO: fast-forward app to right before this DeliverTx, call generate fraudproof, then gossip it to P2P network
+			// fraudTx: current DeliverTx
 		}
 	}
 
@@ -363,7 +364,8 @@ func (e *BlockExecutor) execute(ctx context.Context, state types.State, block *t
 		return nil, err
 	}
 	if isFraud {
-		// TODO: catch up app and call generate fraudproof, then gossip it to P2P network
+		// TODO: fast-forward app to right before EndBlock, call generate fraudproof, then gossip it to P2P network
+		// fraudTx: EndBlock
 	}
 	if block.Data.IntermediateStateRoots.RawRootsList == nil {
 		// Block producer: Initial ISRs generated here

--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -80,7 +80,7 @@ func TestApplyBlock(t *testing.T) {
 	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
 	app.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{})
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
-	app.On("TriggerFraudProofGenerationMode", mock.Anything).Return(abci.ResponseTriggerFraudProofGenerationMode{})
+	app.On("GenerateFraudProof", mock.Anything).Return(abci.ResponseGenerateFraudProof{})
 	var mockAppHash [32]byte
 	_, err := rand.Read(mockAppHash[:])
 	require.NoError(err)


### PR DESCRIPTION
In an optimint full node, after a fraudulent state transition is detected, a Fraud Proof should be generated.

Uses https://github.com/celestiaorg/tendermint/pull/63 for ABCI interface

Closes: #499 