### PR TITLE
replaced [8]byte with types.NamespaceID

### DIFF
--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -68,7 +68,7 @@ func TestInitialState(t *testing.T) {
 	key, _, _ := crypto.GenerateEd25519Key(rand.Reader)
 	conf := config.BlockManagerConfig{
 		BlockTime:   10 * time.Second,
-		NamespaceID: [8]byte{1, 2, 3, 4, 5, 6, 7, 8},
+		NamespaceID: types.NamespaceID{1, 2, 3, 4, 5, 6, 7, 8},
 	}
 
 	for _, c := range cases {

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"time"
 
+	"github.com/celestiaorg/rollmint/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -39,8 +40,8 @@ type BlockManagerConfig struct {
 	// DABlockTime informs about block time of underlying data availability layer
 	DABlockTime time.Duration `mapstructure:"da_block_time"`
 	// DAStartHeight allows skipping first DAStartHeight-1 blocks when querying for blocks.
-	DAStartHeight uint64  `mapstructure:"da_start_height"`
-	NamespaceID   [8]byte `mapstructure:"namespace_id"`
+	DAStartHeight uint64            `mapstructure:"da_start_height"`
+	NamespaceID   types.NamespaceID `mapstructure:"namespace_id"`
 }
 
 // GetViperConfig reads configuration parameters from Viper instance.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/celestiaorg/rollmint/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -32,5 +33,5 @@ func TestViperAndCobra(t *testing.T) {
 	assert.Equal("foobar", nc.DALayer)
 	assert.Equal(`{"json":true}`, nc.DAConfig)
 	assert.Equal(1234*time.Second, nc.BlockTime)
-	assert.Equal([8]byte{1, 2, 3, 4, 5, 6, 7, 8}, nc.NamespaceID)
+	assert.Equal(types.NamespaceID{1, 2, 3, 4, 5, 6, 7, 8}, nc.NamespaceID)
 }

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -1,6 +1,10 @@
 package config
 
-import "time"
+import (
+	"time"
+
+	"github.com/celestiaorg/rollmint/types"
+)
 
 const (
 	// DefaultListenAddress is a default listen address for P2P client.
@@ -16,7 +20,7 @@ var DefaultNodeConfig = NodeConfig{
 	Aggregator: false,
 	BlockManagerConfig: BlockManagerConfig{
 		BlockTime:   30 * time.Second,
-		NamespaceID: [8]byte{},
+		NamespaceID: types.NamespaceID{},
 	},
 	DALayer:  "mock",
 	DAConfig: "",

--- a/da/celestia/celestia.go
+++ b/da/celestia/celestia.go
@@ -20,7 +20,7 @@ import (
 type DataAvailabilityLayerClient struct {
 	client *cnc.Client
 
-	namespaceID [8]byte
+	namespaceID types.NamespaceID
 	config      Config
 	logger      log.Logger
 }
@@ -36,7 +36,7 @@ type Config struct {
 }
 
 // Init initializes DataAvailabilityLayerClient instance.
-func (c *DataAvailabilityLayerClient) Init(namespaceID [8]byte, config []byte, kvStore store.KVStore, logger log.Logger) error {
+func (c *DataAvailabilityLayerClient) Init(namespaceID types.NamespaceID, config []byte, kvStore store.KVStore, logger log.Logger) error {
 	c.namespaceID = namespaceID
 	c.logger = logger
 

--- a/da/da.go
+++ b/da/da.go
@@ -58,7 +58,7 @@ type ResultRetrieveBlocks struct {
 // It also contains life-cycle methods.
 type DataAvailabilityLayerClient interface {
 	// Init is called once to allow DA client to read configuration and initialize resources.
-	Init(namespaceID [8]byte, config []byte, kvStore store.KVStore, logger log.Logger) error
+	Init(namespaceID types.NamespaceID, config []byte, kvStore store.KVStore, logger log.Logger) error
 
 	// Start is called once, after Init. It's implementation should start operation of DataAvailabilityLayerClient.
 	Start() error

--- a/da/grpc/grpc.go
+++ b/da/grpc/grpc.go
@@ -41,7 +41,7 @@ var _ da.DataAvailabilityLayerClient = &DataAvailabilityLayerClient{}
 var _ da.BlockRetriever = &DataAvailabilityLayerClient{}
 
 // Init sets the configuration options.
-func (d *DataAvailabilityLayerClient) Init(_ [8]byte, config []byte, _ store.KVStore, logger log.Logger) error {
+func (d *DataAvailabilityLayerClient) Init(_ types.NamespaceID, config []byte, _ store.KVStore, logger log.Logger) error {
 	d.logger = logger
 	if len(config) == 0 {
 		d.config = DefaultConfig

--- a/da/mock/mock.go
+++ b/da/mock/mock.go
@@ -31,7 +31,7 @@ var _ da.DataAvailabilityLayerClient = &DataAvailabilityLayerClient{}
 var _ da.BlockRetriever = &DataAvailabilityLayerClient{}
 
 // Init is called once to allow DA client to read configuration and initialize resources.
-func (m *DataAvailabilityLayerClient) Init(_ [8]byte, config []byte, dalcKV store.KVStore, logger log.Logger) error {
+func (m *DataAvailabilityLayerClient) Init(_ types.NamespaceID, config []byte, dalcKV store.KVStore, logger log.Logger) error {
 	m.logger = logger
 	m.dalcKV = dalcKV
 	m.daHeight = 1

--- a/da/test/da_test.go
+++ b/da/test/da_test.go
@@ -28,7 +28,7 @@ import (
 
 const mockDaBlockTime = 100 * time.Millisecond
 
-var testNamespaceID = [8]byte{0, 1, 2, 3, 4, 5, 6, 7}
+var testNamespaceID = types.NamespaceID{0, 1, 2, 3, 4, 5, 6, 7}
 
 func TestLifecycle(t *testing.T) {
 	srv := startMockGRPCServ(t)

--- a/docs/lazy-adr/adr-004-core-types.md
+++ b/docs/lazy-adr/adr-004-core-types.md
@@ -40,32 +40,34 @@ If necessary `Tx` could be turned into a struct. Currently, there is no need for
 ### Block Header
 
 ```go
+type NamespaceID [8]byte
+
 type Header struct {
     // Block and App version
-    Version Version 
+    Version Version
     // NamespaceID identifies this chain e.g. when connected to other rollups via IBC.
-    NamespaceID [8]byte  
-    
-    Height  uint64               
-    Time    uint64 // time in tai64 format           
-    
+    NamespaceID NamespaceID
+
+    Height  uint64
+    Time    uint64 // time in tai64 format
+
     // prev block info
-    LastHeaderHash [32]byte 
-    
+    LastHeaderHash [32]byte
+
     // hashes of block data
     LastCommitHash     [32]byte // commit from aggregator(s) from the last block
     DataHash           [32]byte // Block.Data root aka Transactions
     ConsensusHash      [32]byte // consensus params for current block
     AppHash            [32]byte  // state after applying txs from the current block
-    
+
     // root hash of all results from the txs from the previous block
     // This is ABCI specific but smart-contract chains require some way of committing to transaction receipts/results.
     LastResultsHash [32]byte
-    
-    
-    // Note that the address can be derived from the pubkey which can be derived 
+
+
+    // Note that the address can be derived from the pubkey which can be derived
     // from the signature when using secp256k.
-    // We keep this in case users choose another signature format where the 
+    // We keep this in case users choose another signature format where the
     // pubkey can't be recovered by the signature (e.g. ed25519).
     ProposerAddress Address  // original proposer of the block
 }
@@ -74,8 +76,8 @@ type Header struct {
 // including all blockchain data structures and the rules of the application's
 // state transition machine.
 // This is equivalent to the tmversion.Consensus type in Tendermint.
-type Version struct { 
-    Block uint32 
+type Version struct {
+    Block uint32
     App   uint32
 }
 ```
@@ -136,17 +138,17 @@ The ConsensusParams have the exact same structure as in Tendermint. For the sake
 // ConsensusParams contains consensus critical parameters that determine the
 // validity of blocks.
 type ConsensusParams struct {
-    Block     BlockParams     
-    Evidence  EvidenceParams  
-    Validator ValidatorParams 
-    Version   VersionParams   
+    Block     BlockParams
+    Evidence  EvidenceParams
+    Validator ValidatorParams
+    Version   VersionParams
 }
 
 // BlockParams contains limits on the block size.
 type BlockParams struct {
     // Max block size, in bytes.
     // Note: must be greater than 0
-    MaxBytes int64 
+    MaxBytes int64
     // Max gas per block.
     // Note: must be greater or equal to -1
     MaxGas int64
@@ -163,7 +165,7 @@ type EvidenceParams struct {
     //
     // The basic formula for calculating this is: MaxAgeDuration / {average block
     // time}.
-    MaxAgeNumBlocks int64 
+    MaxAgeNumBlocks int64
     // Max age of evidence, in time.
     //
     // It should correspond with an app's "unbonding period" or other similar

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/celestiaorg/rollmint/mocks"
 	"github.com/celestiaorg/rollmint/p2p"
 	"github.com/celestiaorg/rollmint/store"
+	rmtypes "github.com/celestiaorg/rollmint/types"
 )
 
 func TestAggregatorMode(t *testing.T) {
@@ -47,7 +48,7 @@ func TestAggregatorMode(t *testing.T) {
 
 	blockManagerConfig := config.BlockManagerConfig{
 		BlockTime:   1 * time.Second,
-		NamespaceID: [8]byte{1, 2, 3, 4, 5, 6, 7, 8},
+		NamespaceID: rmtypes.NamespaceID{1, 2, 3, 4, 5, 6, 7, 8},
 	}
 	node, err := NewNode(context.Background(), config.NodeConfig{DALayer: "mock", Aggregator: true, BlockManagerConfig: blockManagerConfig}, key, signingKey, abcicli.NewLocalClient(nil, app), &types.GenesisDoc{ChainID: "test"}, log.TestingLogger())
 	require.NoError(err)
@@ -207,7 +208,7 @@ func createNode(ctx context.Context, n int, aggregator bool, dalc da.DataAvailab
 	}
 	bmConfig := config.BlockManagerConfig{
 		BlockTime:   300 * time.Millisecond,
-		NamespaceID: [8]byte{8, 7, 6, 5, 4, 3, 2, 1},
+		NamespaceID: rmtypes.NamespaceID{8, 7, 6, 5, 4, 3, 2, 1},
 	}
 	for i := 0; i < len(keys); i++ {
 		if i == n {

--- a/state/executor.go
+++ b/state/executor.go
@@ -24,7 +24,7 @@ import (
 // BlockExecutor creates and applies blocks and maintains state.
 type BlockExecutor struct {
 	proposerAddress []byte
-	namespaceID     [8]byte
+	namespaceID     types.NamespaceID
 	chainID         string
 	proxyApp        proxy.AppConnConsensus
 	mempool         mempool.Mempool

--- a/types/block.go
+++ b/types/block.go
@@ -4,6 +4,8 @@ import (
 	"encoding"
 )
 
+type NamespaceID [8]byte
+
 // Header defines the structure of rollmint block header.
 type Header struct {
 	// Block and App version
@@ -11,7 +13,7 @@ type Header struct {
 	// NamespaceID identifies this chain e.g. when connected to other rollups via IBC.
 	// TODO(ismail): figure out if we want to use namespace.ID here instead (downside is that it isn't fixed size)
 	// at least extract the used constants (32, 8) as package variables though.
-	NamespaceID [8]byte
+	NamespaceID NamespaceID
 
 	Height uint64
 	Time   uint64 // time in tai64 format

--- a/types/serialization_test.go
+++ b/types/serialization_test.go
@@ -43,7 +43,7 @@ func TestBlockSerializationRoundTrip(t *testing.T) {
 					Block: 1,
 					App:   2,
 				},
-				NamespaceID:     [8]byte{0, 1, 2, 3, 4, 5, 6, 7},
+				NamespaceID:     NamespaceID{0, 1, 2, 3, 4, 5, 6, 7},
 				Height:          3,
 				Time:            4567,
 				LastHeaderHash:  h[0],


### PR DESCRIPTION
I think naming the new type NamespaceID is straightforward and requires no further explanation.

Let me know if I missed something - the go compiler likes it just fine