### PR TITLE
Update build to replace correct module

### DIFF
--- a/.github/workflows/docker-build-test-ethermint.yml
+++ b/.github/workflows/docker-build-test-ethermint.yml
@@ -46,7 +46,7 @@ jobs:
           cp -R rollmint ethermint
           cd ethermint
           rm -rf .git
-          go mod edit -replace=github.com/celestiaorg/rollmint=./rollmint
+          go mod edit -replace=github.com/celestiaorg/optimint=./rollmint
           go mod tidy -compat=1.17 -e
       - name: Docker meta
         id: meta


### PR DESCRIPTION
Ethermint currently imports optimint, so this replace is replacing an unused module currently, testing in rollmint that ethermint works with a specific optimint version.

Update the edit so build tests what it should.