### PR TITLE
fill in all the missing fields of status rpc

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -9,6 +9,7 @@ import (
 const (
 	// DefaultListenAddress is a default listen address for P2P client.
 	DefaultListenAddress = "/ip4/0.0.0.0/tcp/7676"
+	Version              = "0.4.0"
 )
 
 // DefaultNodeConfig keeps default values of NodeConfig

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -204,6 +204,11 @@ func (c *Client) Addrs() []multiaddr.Multiaddr {
 	return c.host.Addrs()
 }
 
+// Info returns client ID, ListenAddr, and Network info
+func (c *Client) Info() (p2p.ID, string, string) {
+	return p2p.ID(c.host.ID().String()), c.conf.ListenAddress, c.chainID
+}
+
 // PeerConnection describe basic information about P2P connection.
 // TODO(tzdybal): move it somewhere
 type PeerConnection struct {


### PR DESCRIPTION
Fill in all the missing fields of Status() rpc for compatibility with Tendermint RPC.
Fixes https://github.com/celestiaorg/rollmint/issues/241

