### PR TITLE
add flag to enable fraud proofs

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -115,7 +115,7 @@ func NewManager(
 		conf.DABlockTime = defaultDABlockTime
 	}
 
-	exec := state.NewBlockExecutor(proposerAddress, conf.NamespaceID, genesis.ChainID, mempool, proxyApp, eventBus, logger)
+	exec := state.NewBlockExecutor(proposerAddress, conf.NamespaceID, genesis.ChainID, mempool, proxyApp, conf.FraudProofs, eventBus, logger)
 	if s.LastBlockHeight+1 == genesis.InitialHeight {
 		res, err := exec.InitChain(genesis)
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ const (
 	flagDABlockTime   = "rollmint.da_block_time"
 	flagDAStartHeight = "rollmint.da_start_height"
 	flagNamespaceID   = "rollmint.namespace_id"
+	flagFraudProofs   = "rollmint.experimental_insecure_fraud_proofs"
 )
 
 // NodeConfig stores rollmint node configuration.
@@ -43,6 +44,7 @@ type BlockManagerConfig struct {
 	// DAStartHeight allows skipping first DAStartHeight-1 blocks when querying for blocks.
 	DAStartHeight uint64            `mapstructure:"da_start_height"`
 	NamespaceID   types.NamespaceID `mapstructure:"namespace_id"`
+	FraudProofs   bool              `mapstructure:"fraud_proofs"`
 }
 
 // GetViperConfig reads configuration parameters from Viper instance.
@@ -56,6 +58,7 @@ func (nc *NodeConfig) GetViperConfig(v *viper.Viper) error {
 	nc.DABlockTime = v.GetDuration(flagDABlockTime)
 	nc.BlockTime = v.GetDuration(flagBlockTime)
 	nsID := v.GetString(flagNamespaceID)
+	nc.FraudProofs = v.GetBool(flagFraudProofs)
 	bytes, err := hex.DecodeString(nsID)
 	if err != nil {
 		return err
@@ -76,4 +79,5 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.Flags().Duration(flagDABlockTime, def.DABlockTime, "DA chain block time (for syncing)")
 	cmd.Flags().Uint64(flagDAStartHeight, def.DAStartHeight, "starting DA block height (for syncing)")
 	cmd.Flags().BytesHex(flagNamespaceID, def.NamespaceID[:], "namespace identifies (8 bytes in hex)")
+	cmd.Flags().Bool(flagFraudProofs, def.FraudProofs, "enable fraud proofs (experimental & insecure)")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,6 +26,7 @@ func TestViperAndCobra(t *testing.T) {
 	assert.NoError(cmd.Flags().Set(flagDAConfig, `{"json":true}`))
 	assert.NoError(cmd.Flags().Set(flagBlockTime, "1234s"))
 	assert.NoError(cmd.Flags().Set(flagNamespaceID, "0102030405060708"))
+	assert.NoError(cmd.Flags().Set(flagFraudProofs, "false"))
 
 	nc := DefaultNodeConfig
 	assert.NoError(nc.GetViperConfig(v))
@@ -35,4 +36,5 @@ func TestViperAndCobra(t *testing.T) {
 	assert.Equal(`{"json":true}`, nc.DAConfig)
 	assert.Equal(1234*time.Second, nc.BlockTime)
 	assert.Equal(types.NamespaceID{1, 2, 3, 4, 5, 6, 7, 8}, nc.NamespaceID)
+	assert.Equal(false, nc.FraudProofs)
 }

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -22,6 +22,7 @@ var DefaultNodeConfig = NodeConfig{
 	BlockManagerConfig: BlockManagerConfig{
 		BlockTime:   30 * time.Second,
 		NamespaceID: types.NamespaceID{},
+		FraudProofs: false,
 	},
 	DALayer:  "mock",
 	DAConfig: "",

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -282,6 +282,7 @@ func createNode(ctx context.Context, n int, isMalicious bool, aggregator bool, d
 	bmConfig := config.BlockManagerConfig{
 		BlockTime:   300 * time.Millisecond,
 		NamespaceID: rmtypes.NamespaceID{8, 7, 6, 5, 4, 3, 2, 1},
+		FraudProofs: true,
 	}
 	for i := 0; i < len(keys); i++ {
 		if i == n {

--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/celestiaorg/rollmint/types"
 )
 
-func TestCreateBlock(t *testing.T) {
+func doTestCreateBlock(t *testing.T, fraudProofsEnabled bool) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -39,7 +39,7 @@ func TestCreateBlock(t *testing.T) {
 	nsID := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
 
 	mpool := mempoolv1.NewTxMempool(logger, cfg.DefaultMempoolConfig(), proxy.NewAppConnMempool(client), 0)
-	executor := NewBlockExecutor([]byte("test address"), nsID, "test", mpool, proxy.NewAppConnConsensus(client), nil, logger)
+	executor := NewBlockExecutor([]byte("test address"), nsID, "test", mpool, proxy.NewAppConnConsensus(client), fraudProofsEnabled, nil, logger)
 
 	state := types.State{}
 	state.ConsensusParams.Block.MaxBytes = 100
@@ -70,7 +70,15 @@ func TestCreateBlock(t *testing.T) {
 	assert.Len(block.Data.Txs, 2)
 }
 
-func TestApplyBlock(t *testing.T) {
+func TestCreateBlockWithFraudProofsDisabled(t *testing.T) {
+	doTestCreateBlock(t, false)
+}
+
+func TestCreateBlockWithFraudProofsEnabled(t *testing.T) {
+	doTestCreateBlock(t, true)
+}
+
+func doTestApplyBlock(t *testing.T, fraudProofsEnabled bool) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -102,7 +110,7 @@ func TestApplyBlock(t *testing.T) {
 	mpool := mempoolv1.NewTxMempool(logger, cfg.DefaultMempoolConfig(), proxy.NewAppConnMempool(client), 0)
 	eventBus := tmtypes.NewEventBus()
 	require.NoError(eventBus.Start())
-	executor := NewBlockExecutor([]byte("test address"), nsID, chainID, mpool, proxy.NewAppConnConsensus(client), eventBus, logger)
+	executor := NewBlockExecutor([]byte("test address"), nsID, chainID, mpool, proxy.NewAppConnConsensus(client), fraudProofsEnabled, eventBus, logger)
 
 	txQuery, err := query.New("tm.event='Tx'")
 	require.NoError(err)
@@ -189,4 +197,12 @@ func TestApplyBlock(t *testing.T) {
 			assert.EqualValues(3, data.NumTxs)
 		}
 	}
+}
+
+func TestApplyBlockWithFraudProofsDisabled(t *testing.T) {
+	doTestApplyBlock(t, false)
+}
+
+func TestApplyBlockWithFraudProofsEnabled(t *testing.T) {
+	doTestApplyBlock(t, true)
 }


### PR DESCRIPTION
Fixes https://github.com/celestiaorg/rollmint/issues/619 by adding a flag to enable fraud proofs. Note that, there is a change in the default behavior after this commit is merged, where previously by default the fraud proofs were enabled, but now they will be disabled and the flag `--rollmint.experimental_insecure_fraud_proofs` must be passed enable fraud proofs.