### PR TITLE
Resolve discrepancy between Aggregator and Full Nodes in Integration Test

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -461,6 +461,13 @@ func (m *Manager) publishBlock(ctx context.Context) error {
 
 	// Apply the block but DONT commit
 	newState, responses, err := m.executor.ApplyBlock(ctx, m.lastState, block)
+
+	if err != nil {
+		return err
+	}
+
+	// SaveBlock commits the DB tx
+	err = m.store.SaveBlock(block, commit)
 	if err != nil {
 		return err
 	}

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	mrand "math/rand"
 	"strconv"
 	"strings"
@@ -127,9 +128,7 @@ func TestTxGossipingAndAggregation(t *testing.T) {
 			require.NoError(err)
 			nodeBlock, err := nodes[i].Store.LoadBlock(h)
 			require.NoError(err)
-			// Only Intermediate state roots set by block aggregator are relevant, removed for sake of comparison
-			nodeBlock.Data.IntermediateStateRoots.RawRootsList = nil
-			assert.Equal(aggBlock, nodeBlock)
+			assert.Equal(aggBlock, nodeBlock, fmt.Sprintf("height: %d", h))
 		}
 	}
 }
@@ -186,8 +185,6 @@ func TestFraudProofTrigger(t *testing.T) {
 			require.NoError(err)
 			aggBlock, err := nodes[0].Store.LoadBlock(h)
 			require.NoError(err)
-			// Only Intermediate state roots set by block aggregator are relevant, removed for sake of comparison
-			nodeBlock.Data.IntermediateStateRoots.RawRootsList = nil
 			assert.Equal(aggBlock, nodeBlock)
 		}
 	}
@@ -198,7 +195,7 @@ func createAndStartNodes(clientNodes int, isMalicious bool, t *testing.T) ([]*No
 	var wg sync.WaitGroup
 	aggCtx, aggCancel := context.WithCancel(context.Background())
 	ctx, cancel := context.WithCancel(context.Background())
-	nodes, apps := createNodes(aggCtx, ctx, clientNodes+1, true, &wg, t)
+	nodes, apps := createNodes(aggCtx, ctx, clientNodes+1, isMalicious, &wg, t)
 	startNodes(nodes, &wg, t)
 	aggCancel()
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
The discrepancy stems from how an `Aggregator` and `Full Node` call `SaveNode`. Before, the `Aggregator` did not `SaveNode` after calling `ApplyBlock`. Since `ApplyBlock` modifies the `ISR` list in the block data, we need to call `SaveNode` again.

Also, resolves a issue with passing `isMalicious` boolean correctly in the integration test when creating and starting nodes.

Closes: #566 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
