### PR TITLE
Update required go vesion in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ABCI-client implementation for Optimistic Rollups.
 
 ## Building From Source
 
-Requires Go version >= 1.17.
+Requires Go version >= 1.19.
 
 To build:
 


### PR DESCRIPTION
Just noticed, that Go version mentioned in readme is old and has to be updated.